### PR TITLE
Updated (Readme.md): Multiple Instances section

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,12 +252,12 @@ It is possible to have any number of pagination pipe/controls pairs in the same 
 <ul>
   <li *ngFor="let item of collection | paginate: { itemsPerPage: 10, currentPage: p1, id: 'first' }"> ... </li>
 </ul>
-<pagination-controls (pageChange)="p = $event" id="first"></pagination-controls>
+<pagination-controls (pageChange)="p1 = $event" id="first"></pagination-controls>
 
 <ul>
   <li *ngFor="let item of collection | paginate: { itemsPerPage: 10, currentPage: p2, id: 'second' }"> ... </li>
 </ul>
-<pagination-controls (pageChange)="p = $event" id="second"></pagination-controls>
+<pagination-controls (pageChange)="p2 = $event" id="second"></pagination-controls>
 ```
 
 You can even have dynamically-generated instances, e.g. within an `ngFor` block:


### PR DESCRIPTION
The example doesn't work because variable ```p``` it doesn't match with  ```currentPage``` property . I've just change the variables in each ```(pageChange)``` from ```p``` to ```p1``` and ```p2``` respectively.