### PR TITLE
fix: remove extra spacing between li

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -62,7 +62,8 @@ export const DEFAULT_STYLES = `
     margin-right: 0.0625rem;
     border-radius: 0; }
   .ngx-pagination li {
-    display: inline-block; }
+    display: inline-block;
+    float: left; }
   .ngx-pagination a,
   .ngx-pagination button {
     color: #0a0a0a; 

--- a/src/template.ts
+++ b/src/template.ts
@@ -49,7 +49,8 @@ export const DEFAULT_TEMPLATE = `
 export const DEFAULT_STYLES = `
 .ngx-pagination {
   margin-left: 0;
-  margin-bottom: 1rem; }
+  margin-bottom: 1rem;
+  list-style:none; }
   .ngx-pagination::before, .ngx-pagination::after {
     content: ' ';
     display: table; }
@@ -62,7 +63,6 @@ export const DEFAULT_STYLES = `
     margin-right: 0.0625rem;
     border-radius: 0; }
   .ngx-pagination li {
-    display: inline-block;
     float: left; }
   .ngx-pagination a,
   .ngx-pagination button {


### PR DESCRIPTION
This removes extra spacing between `li` elements apart from padding and margin. 

Usually, this happens with `inline-block` elements and using `float` will fix it.