### PR TITLE
throw warn if installed by Angular 4 or less

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "zone.js": "^0.9.1"
   },
   "peerDependencies": {
-    "@angular/core": ">=2.3.1",
-    "@angular/common": ">=2.3.1"
+    "@angular/core": ">=5.0.0",
+    "@angular/common": ">=5.0.0"
   }
 }


### PR DESCRIPTION
Regarding changelog 4.0.0 info, peerDependencies should throw warn if installed by Angular 4 or less.