### PR TITLE
Fix number formatting in case its > 1000 #307

### DIFF
--- a/src/pagination-controls.component.spec.ts
+++ b/src/pagination-controls.component.spec.ts
@@ -1,18 +1,23 @@
 import {By} from '@angular/platform-browser';
 import {TestBed, fakeAsync, tick, ComponentFixture} from '@angular/core/testing';
-import {DebugElement} from '@angular/core';
+import {DebugElement, LOCALE_ID} from '@angular/core';
 import {PaginationControlsComponent} from './pagination-controls.component';
 import {getPageLinkItems, ComponentTestComponent, overrideTemplate, getControlsDirective} from './testing/testing-helpers';
 import {PaginationService} from './pagination.service';
 import {PaginatePipe} from './paginate.pipe';
 import {PaginationControlsDirective} from './pagination-controls.directive';
 
+import { registerLocaleData } from '@angular/common';
+import localeDe from '@angular/common/locales/de';
+
+registerLocaleData(localeDe)
+
 describe('PaginationControlsComponent:', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
             declarations: [PaginationControlsComponent, PaginationControlsDirective, ComponentTestComponent, PaginatePipe],
-            providers: [PaginationService],
+            providers: [PaginationService, {provide: LOCALE_ID, useValue: 'en_US' }],
         });
     });
 
@@ -24,6 +29,35 @@ describe('PaginationControlsComponent:', () => {
 
         let expected = ['1', '2', '3', '4'];
 
+        expect(getPageLinkItems(fixture)).toEqual(expected);
+    }));
+
+
+    it('should display the correct page links (formatted numbers over 1000) with comma', fakeAsync(() => {
+        let fixture = TestBed.createComponent(ComponentTestComponent);
+        let instance = fixture.componentInstance;
+        instance.collection = Array.from(new Array(1000), (x, i) => `item ${i + 1}`);
+        instance.config.itemsPerPage = 1;
+        fixture.detectChanges();
+
+        let expected = ['1', '2', '3', '4', '5', '6', '7', '...', '1,000'];
+        expect(getPageLinkItems(fixture)).toEqual(expected);
+    }));
+    
+    
+    it('should display the correct page links (formatted numbers over 1000) with dot', fakeAsync(() => {
+        TestBed.configureTestingModule({
+            declarations: [PaginationControlsComponent, PaginationControlsDirective, ComponentTestComponent, PaginatePipe],
+            providers: [PaginationService, {provide: LOCALE_ID, useValue: 'de_DE' }],
+        });
+
+        let fixture = TestBed.createComponent(ComponentTestComponent);
+        let instance = fixture.componentInstance;
+        instance.collection = Array.from(new Array(1000), (x, i) => `item ${i + 1}`);
+        instance.config.itemsPerPage = 1;
+        fixture.detectChanges();
+
+        let expected = ['1', '2', '3', '4', '5', '6', '7', '...', '1.000'];
         expect(getPageLinkItems(fixture)).toEqual(expected);
     }));
 

--- a/src/template.ts
+++ b/src/template.ts
@@ -32,11 +32,11 @@ export const DEFAULT_TEMPLATE = `
             *ngFor="let page of p.pages">
             <a tabindex="0" (keyup.enter)="p.setCurrent(page.value)" (click)="p.setCurrent(page.value)" *ngIf="p.getCurrent() !== page.value">
                 <span class="show-for-sr">{{ screenReaderPageLabel }} </span>
-                <span>{{ page.label | number:'':'fr-FR' }}</span>
+                <span>{{ (page.label === '...') ? page.label : (page.label | number:'') }}</span>
             </a>
             <ng-container *ngIf="p.getCurrent() === page.value">
                 <span class="show-for-sr">{{ screenReaderCurrentLabel }} </span>
-                <span>{{ page.label | number:'':'fr-FR' }}</span> 
+                <span>{{ (page.label === '...') ? page.label : (page.label | number:'') }}</span> 
             </ng-container>
         </li>
 

--- a/src/template.ts
+++ b/src/template.ts
@@ -32,11 +32,11 @@ export const DEFAULT_TEMPLATE = `
             *ngFor="let page of p.pages">
             <a tabindex="0" (keyup.enter)="p.setCurrent(page.value)" (click)="p.setCurrent(page.value)" *ngIf="p.getCurrent() !== page.value">
                 <span class="show-for-sr">{{ screenReaderPageLabel }} </span>
-                <span>{{ page.label }}</span>
+                <span>{{ page.label | number:'':'fr-FR' }}</span>
             </a>
             <ng-container *ngIf="p.getCurrent() === page.value">
                 <span class="show-for-sr">{{ screenReaderCurrentLabel }} </span>
-                <span>{{ page.label }}</span> 
+                <span>{{ page.label | number:'':'fr-FR' }}</span> 
             </ng-container>
         </li>
 

--- a/src/testing/testing-helpers.ts
+++ b/src/testing/testing-helpers.ts
@@ -46,8 +46,10 @@ export function getPageLinkItems(fixture: ComponentFixture<any>,
     if (includeAll) {
         return all;
     } else {
-        return all.filter(str => str.match(/\d+|\.\.\./))
-            .map(str => str.match(/\d+|\.\.\./)[0]);
+        return all.filter(str => {
+            return str.match(/\d*\,?\.?\d+|\.\.\./)
+        })
+            .map(str => str.match(/\d*\,?\.?\d+|\.\.\./)[0]);
     }
 }
 


### PR DESCRIPTION
Here is a fix for #307. (I know another PR already exists, but since i started before that i am gonna submit the PR anyways)

* added a check for the `...` to not apply the pipe in this case
* added a test case for locale US to check if `.` is used as separator
* added a test case for locale DE to check if `,` is used as separator