### PR TITLE
Fix broken link on the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ template to access the directive's API methods and properties, which are explain
 * **`getLastPage()`** [`() => number`] Returns the page number of the last page.
 * **`getTotalItems()`** [`() => number`] Returns the total number of items in the collection.
 
-For a real-world implementation of a custom component, take a look at [the source for the PaginationControlsComponent](/src/pagination-controls.component.ts).
+For a real-world implementation of a custom component, take a look at [the source for the PaginationControlsComponent](/projects/ngx-pagination/src/lib/pagination-controls.component.ts).
 
 ## Styling
 


### PR DESCRIPTION
- Angular version: v13.3.11

- ngx-pagination version: v6.0.2

- Description of issue: Broken link on `README.md` file

- Steps to reproduce: 
1. Visit https://michaelbromley.github.io/ngx-pagination/ and find the part with
2. Find the part with "For a real-world implementation of a custom component, take a look at `the source for the PaginationControlsComponent.`"

- Expected result: Link should work and redirect to:
`https://github.com/michaelbromley/ngx-pagination/blob/master/projects/ngx-pagination/src/lib/pagination-controls.component.ts`

- Actual result: 404 
