### PR TITLE
Fix broken "PaginationInstance" link on the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ export class MyComponent {
 ### PaginatePipe
 
 The PaginatePipe should be placed at the end of an NgFor expression. It accepts a single argument, an object conforming 
-to the [`PaginationInstance` interface](/src/pagination-instance.ts). The following config options are available:
+to the [`PaginationInstance` interface](/projects/ngx-pagination/src/lib/pagination-instance.ts). The following config options are available:
 
 ```HTML
 <some-element *ngFor="let item of collection | paginate: { id: 'foo',


### PR DESCRIPTION
**Angular version**: v13.3.11

**ngx-pagination version**: v6.0.2

**Description of issue**: Broken link on README.md

**Steps to reproduce:** 
1. Visit https://michaelbromley.github.io/ngx-pagination/ and find the part with
2. Find the part with "an object conforming to the PaginationInstance interface"

**Expected result:** Link should work

**Actual result:** 404 
